### PR TITLE
Collect symbols for ARM64 binaries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ WinDbg symbols for CPython
     :target: https://github.com/SeanCline/PythonSymbols/actions
     :alt: Build Status
 
-This repository hosts the symbols for all recent Windows builds of the CPython interpreter. (Both x86 and x64.)
+This repository hosts the symbols for all recent Windows builds of the CPython interpreter (x86, x64, and ARM64).
 
 It stays up to date automatically by looking for new Python releases weekly and adding their symbols to the symbols store.
 

--- a/pysymsrv.py
+++ b/pysymsrv.py
@@ -67,6 +67,7 @@ def download_pdbs_for_version(root, version, target_dir, already_downloaded_file
         os.makedirs(target_dir)
         os.makedirs(os.path.join(target_dir, "win32"))
         os.makedirs(os.path.join(target_dir, "amd64"))
+        os.makedirs(os.path.join(target_dir, "arm64"))
     
     archives = [
         "python-" + version + "-pdb.zip", # Python 2.x
@@ -81,6 +82,11 @@ def download_pdbs_for_version(root, version, target_dir, already_downloaded_file
         "amd64/lib_pdb.msi", # Python 3.x
         "amd64/tkltk_pdb.msi", # Python 3.x
         "amd64/test_pdb.msi", # Python 3.x
+        "arm64/core_pdb.msi", # Python 3.x
+        "arm64/exe_pdb.msi", # Python 3.x
+        "arm64/lib_pdb.msi", # Python 3.x
+        "arm64/tkltk_pdb.msi", # Python 3.x
+        "arm64/test_pdb.msi", # Python 3.x
     ]
     
     for archive in archives:


### PR DESCRIPTION
This adds support for collecting symbols for the ARM64 builds of CPython provided since 3.11.0.