### PR TITLE
Fix default branch name for PR and push triggers

### DIFF
--- a/.github/workflows/python-symbols-publish.yaml
+++ b/.github/workflows/python-symbols-publish.yaml
@@ -44,6 +44,7 @@ jobs:
         run: |
           python generateindex.py
       - name: Deploy new symbols to GH Pages.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           # date > lastrun.txt
           git add --all :/

--- a/.github/workflows/python-symbols-publish.yaml
+++ b/.github/workflows/python-symbols-publish.yaml
@@ -3,10 +3,10 @@ name: PythonSymbols
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
   schedule:
     - cron: "0 0 * * 0"
 


### PR DESCRIPTION
Looks like you probably renamed `master` to `main` at some point and forgot to change the GitHub Action workflows.

I also realized when making this change that the workflow would actually deploy symbols if the PR trigger fired (a user created a PR targeting main). You definitely don't want that, so I modified it to avoid doing the commit except on a push to the main branch.